### PR TITLE
fix: Removes all trailing and leading whitespace, including tabs and new lines

### DIFF
--- a/src/__test__/cleanAnswer.test.ts
+++ b/src/__test__/cleanAnswer.test.ts
@@ -56,7 +56,12 @@ describe(`#${cleanAnswer.name}()`, () => {
         it("cleans the output", () => {
             const cleaned = cleanAnswer("\n\n\n\tHello!");
             expect(cleaned).to.exist;
-            expect(cleaned).to.equal("\tHello!");
+            expect(cleaned).to.equal("Hello!");
+
+            // jUst one
+            const cleaned0 = cleanAnswer("\nHello!\n\n");
+            expect(cleaned0).to.exist;
+            expect(cleaned0).to.equal("Hello!");
         });
     });
 });

--- a/src/cleanAnswer.ts
+++ b/src/cleanAnswer.ts
@@ -18,6 +18,8 @@ export function cleanAnswer(answer: string): string {
     }
 
     answer = cleanTags(answer);
+    // Removes all leading/trailing whitespace
+    answer = answer.replace(/^\s+|\s+$/g, '');
     // Remove spaces when more then 2
     answer = answer.replace(/( ){3,}/g, '');
     // Remove tabs when more than one


### PR DESCRIPTION
We were running into scenarios where a snippet started with a `\n` and made the quotes look funny.

![image](https://user-images.githubusercontent.com/921356/164531744-06076be7-9d73-4c0c-b386-119b0b3482d5.png)
