### PR TITLE
fix: Attempt at addressing multi-line markdown bolding

### DIFF
--- a/src/__test__/cleanAnswer.test.ts
+++ b/src/__test__/cleanAnswer.test.ts
@@ -64,4 +64,12 @@ describe(`#${cleanAnswer.name}()`, () => {
             expect(cleaned0).to.equal("Hello!");
         });
     });
+    describe("with markdown that has newlines", () => {
+        it("cleans the output", () => {
+            const cleaned = cleanAnswer("Here is what I found...\n\"**Put Certified Professionals in Your Corner\n\nFully licensed and insured**, we use only the highest quality materials in the industry and works with the most experienced employees and contractors.\"\nAny other questions?");
+            expect(cleaned).to.exist;
+            expect(cleaned).to.contain("**Put Certified Professionals in Your Corner**");
+            expect(cleaned).to.contain("**Fully licensed and insured**");
+        });
+    });
 });

--- a/src/__test__/utils.test.ts
+++ b/src/__test__/utils.test.ts
@@ -22,6 +22,6 @@ describe(`#${addMarkdownHighlight.name}()`, () => {
 describe(`#${addMarkdownHighlights.name}()`, () => {
     it("returns the correct value", () => {
         const highlights = [{ beginOffset: 2, endOffset: 3 }, { beginOffset: 6, endOffset: 7 }]
-        expect(addMarkdownHighlights("a b c d e", highlights)).to.equal("a **b** c **d** e")
+        expect(addMarkdownHighlights("a b c d e", highlights)).to.equal("a **b** c **d** e");
     });
 });

--- a/src/cleanAnswer.ts
+++ b/src/cleanAnswer.ts
@@ -33,5 +33,12 @@ export function cleanAnswer(answer: string): string {
     // This is one more check where the above step could have helped clean up but we end up with a combination of \n & spaces.
     answer = answer.replace(/(\n| ){3,}/g, '\n\n');
 
+    // Markdown Clean up
+    // This is trying out something here.
+    // Markdown bolding does not go over two new lines (\n) so this looks for that case
+    // and attempts to close them.  It is targeting a very specific case
+    // See https://regex101.com/r/7lOVOG/1
+    answer = answer.replace(/\*\*([\S ]+)([\r\n]+)([\S ]+)\*\*/gm, `**$1**$2**$3**`);
+
     return answer;
 }


### PR DESCRIPTION
This is a very targeted attempt to fix when the highlights span over several new lines and then doesn't get converted to HTML correctly.
![bolding-across-new-lines](https://user-images.githubusercontent.com/921356/167979712-47defd62-b682-42e3-ada3-7123cb8fd8ae.png)

