### PR TITLE
fix: Move from Session to Request Attributes

### DIFF
--- a/src/QuestionAnsweringHandler.ts
+++ b/src/QuestionAnsweringHandler.ts
@@ -80,13 +80,22 @@ export class QuestionAnsweringHandler<C extends Content = Content, D extends Que
         const result: KnowledgeBaseResult = context.session.get(SESSION_STORAGE_KNOWLEDGE_BASE_RESULT);
         // Generate the variables that will be injected!
         const variables = generateResultVariables(request.rawQuery, result, this.data);
-        // For each variable, we drop them on the session variable
+
+        // make sure we have attributes on the request
+        if (!request.attributes) {
+            request.attributes = {};
+        }
+
+        // For each variable, we drop them on the request variable
         RESULT_VARIABLE_KEYS.forEach((key) => {
             const value = variables[key];
+            // session has a problem because it lasts the entire session
+            // we might need to keep these forever because of the 
+            // existing macros and responses out there being used
             context.session.set(key, value);
+            // this will be the new way because it clears out after each request
+            request.attributes[key] = value;
         });
-
-        // Do I clean out old ones?  I think so.
 
         log().info(`Variables: ${Object.keys(variables)}`);
         log().debug(JSON.stringify(variables, undefined, 2));

--- a/src/__test__/generateDefaultResponse.test.ts
+++ b/src/__test__/generateDefaultResponse.test.ts
@@ -47,17 +47,19 @@ describe(`#${generateDefaultResponse.name}()`, () => {
     });
     describe(`for intelligent search channel`, () => {
         it("returns as expected", () => {
-            request = { ...REQUEST_WITH_GOOD_HIGHLIGHTED_ANSWER };
-            request.channel = "intelligent-search";
 
             const sessionVariables = generateResultVariables(request.rawQuery, REQUEST_WITH_GOOD_HIGHLIGHTED_ANSWER.knowledgeBaseResult, {});
+
+            request = { ...REQUEST_WITH_GOOD_HIGHLIGHTED_ANSWER };
+            request.channel = "intelligent-search";
+            request.attributes = { ...sessionVariables };
 
             context = new ContextBuilder()
                 .withSessionData({
                     id: "foo",
                     data: {
                         [SESSION_STORAGE_KNOWLEDGE_BASE_RESULT]: REQUEST_WITH_GOOD_HIGHLIGHTED_ANSWER.knowledgeBaseResult,
-                        ...sessionVariables
+                        // ...sessionVariables
                     }
                 })
                 .build();
@@ -89,17 +91,18 @@ describe(`#${generateDefaultResponse.name}()`, () => {
         describe("for results only", () => {
             it("returns as expected", () => {
 
+                const sessionVariables = generateResultVariables(request.rawQuery, REQUEST_KNOWLEDGEBASE_NO_SUGGEST_OR_FAQ.knowledgeBaseResult, {});
+
                 request = { ...REQUEST_KNOWLEDGEBASE_NO_SUGGEST_OR_FAQ };
                 request.channel = "intelligent-search";
-
-                const sessionVariables = generateResultVariables(request.rawQuery, REQUEST_KNOWLEDGEBASE_NO_SUGGEST_OR_FAQ.knowledgeBaseResult, {});
+                request.attributes = { ...sessionVariables };
 
                 context = new ContextBuilder()
                     .withSessionData({
                         id: "foo",
                         data: {
                             [SESSION_STORAGE_KNOWLEDGE_BASE_RESULT]: REQUEST_KNOWLEDGEBASE_NO_SUGGEST_OR_FAQ.knowledgeBaseResult,
-                            ...sessionVariables
+                            //...sessionVariables
                         }
                     })
                     .build();
@@ -194,12 +197,14 @@ describe(`#${generateDefaultResponse.name}()`, () => {
 
                 const sessionVariables = generateResultVariables(request.rawQuery, kb, {});
 
+                request.attributes = { ...sessionVariables };
+
                 context = new ContextBuilder()
                     .withSessionData({
                         id: "foo",
                         data: {
                             [SESSION_STORAGE_KNOWLEDGE_BASE_RESULT]: kb,
-                            ...sessionVariables
+                            // ...sessionVariables
                         }
                     })
                     .build();
@@ -276,12 +281,14 @@ describe(`#${generateDefaultResponse.name}()`, () => {
 
                 const sessionVariables = generateResultVariables(request.rawQuery, kb, {});
 
+                request.attributes = { ...sessionVariables };
+
                 context = new ContextBuilder()
                     .withSessionData({
                         id: "foo",
                         data: {
                             [SESSION_STORAGE_KNOWLEDGE_BASE_RESULT]: kb,
-                            ...sessionVariables
+                            //...sessionVariables
                         }
                     })
                     .build();
@@ -320,12 +327,14 @@ describe(`#${generateDefaultResponse.name}()`, () => {
 
             const sessionVariables = generateResultVariables(request.rawQuery, REQUEST_WITH_GOOD_HIGHLIGHTED_ANSWER.knowledgeBaseResult, {});
 
+            request.attributes = { ...sessionVariables };
+
             context = new ContextBuilder()
                 .withSessionData({
                     id: "foo",
                     data: {
                         [SESSION_STORAGE_KNOWLEDGE_BASE_RESULT]: REQUEST_WITH_GOOD_HIGHLIGHTED_ANSWER.knowledgeBaseResult,
-                        ...sessionVariables
+                        // ...sessionVariables
                     }
                 })
                 .build();
@@ -366,12 +375,14 @@ describe(`#${generateDefaultResponse.name}()`, () => {
 
                 const sessionVariables = generateResultVariables(request.rawQuery, kb, {});
 
+                request.attributes = { ...sessionVariables };
+
                 context = new ContextBuilder()
                     .withSessionData({
                         id: "foo",
                         data: {
                             [SESSION_STORAGE_KNOWLEDGE_BASE_RESULT]: kb,
-                            ...sessionVariables
+                            // ...sessionVariables
                         }
                     })
                     .build();
@@ -422,6 +433,8 @@ describe(`#${generateDefaultResponse.name}()`, () => {
 
                 const sessionVariables = generateResultVariables(request.rawQuery, kb, {});
 
+                request.attributes = { ...sessionVariables };
+
                 context = new ContextBuilder()
                     .withSessionData({
                         id: "foo",
@@ -457,9 +470,11 @@ describe(`#${generateDefaultResponse.name}()`, () => {
         });
         describe("for just list of results", () => {
             it("returns as expected", () => {
-                request = REQUEST_KNOWLEDGEBASE_NO_SUGGEST_OR_FAQ;
 
                 const sessionVariables = generateResultVariables(request.rawQuery, REQUEST_KNOWLEDGEBASE_NO_SUGGEST_OR_FAQ.knowledgeBaseResult, {});
+
+                request = REQUEST_KNOWLEDGEBASE_NO_SUGGEST_OR_FAQ;
+                request.attributes = { ...sessionVariables };
 
                 context = new ContextBuilder()
                     .withSessionData({
@@ -514,12 +529,14 @@ describe(`#${generateDefaultResponse.name}()`, () => {
 
                 const sessionVariables = generateResultVariables(request.rawQuery, kbResult, {});
 
+                request.attributes = { ...sessionVariables };
+
                 context = new ContextBuilder()
                     .withSessionData({
                         id: "foo",
                         data: {
                             [SESSION_STORAGE_KNOWLEDGE_BASE_RESULT]: REQUEST_KNOWLEDGEBASE_NO_SUGGEST_OR_FAQ.knowledgeBaseResult,
-                            ...sessionVariables
+                            //...sessionVariables
                         }
                     })
                     .build();
@@ -548,6 +565,7 @@ describe(`#${generateDefaultResponse.name}()`, () => {
         describe("for just FAQs", () => {
             it("returns as expected", () => {
 
+
                 request = REQUEST_KNOWLEDGEBASE_NO_SUGGEST_OR_FAQ;
 
                 const kbResult = { ...REQUEST_KNOWLEDGEBASE_NO_SUGGEST_OR_FAQ.knowledgeBaseResult };
@@ -557,16 +575,18 @@ describe(`#${generateDefaultResponse.name}()`, () => {
                         question: "What is the meaning of life?",
                         document: "42"
                     }
-                ]
+                ];
 
                 const sessionVariables = generateResultVariables(request.rawQuery, kbResult, {});
+
+                request.attributes = { ...sessionVariables };
 
                 context = new ContextBuilder()
                     .withSessionData({
                         id: "foo",
                         data: {
                             [SESSION_STORAGE_KNOWLEDGE_BASE_RESULT]: REQUEST_KNOWLEDGEBASE_NO_SUGGEST_OR_FAQ.knowledgeBaseResult,
-                            ...sessionVariables
+                            // ...sessionVariables
                         }
                     })
                     .build();
@@ -592,16 +612,16 @@ describe(`#${generateDefaultResponse.name}()`, () => {
         describe("with CHAT_RESPONSE variables", () => {
             it("returns as expected", () => {
 
-                request = new IntentRequestBuilder().withRawQuery("what is the answer").withIntentId("OCSearch").build();
-
                 const sessionVariables = { ...VARIABLES_WITH_CHAT };
+
+                request = new IntentRequestBuilder().withRawQuery("what is the answer").withIntentId("OCSearch").withAttributes({ ...sessionVariables }).build();
 
                 context = new ContextBuilder()
                     .withSessionData({
                         id: "foo",
                         data: {
                             [SESSION_STORAGE_KNOWLEDGE_BASE_RESULT]: REQUEST_WITH_GOOD_HIGHLIGHTED_ANSWER.knowledgeBaseResult,
-                            ...sessionVariables
+                            //...sessionVariables
                         }
                     })
                     .build();
@@ -623,16 +643,17 @@ describe(`#${generateDefaultResponse.name}()`, () => {
             describe("with a follow up question already on the text", () => {
                 it("returns as expected", () => {
 
-                    request = new IntentRequestBuilder().withRawQuery("what is the answer").withIntentId("OCSearch").build();
-
                     const sessionVariables = { ...VARIABLES_WITH_CHAT_AND_FOLLOW_UP };
+
+                    request = new IntentRequestBuilder().withRawQuery("what is the answer").withIntentId("OCSearch").withAttributes({ ...sessionVariables }).build();
 
                     context = new ContextBuilder()
                         .withSessionData({
                             id: "foo",
                             data: {
                                 [SESSION_STORAGE_KNOWLEDGE_BASE_RESULT]: REQUEST_WITH_GOOD_HIGHLIGHTED_ANSWER.knowledgeBaseResult,
-                                ...sessionVariables
+                                // old method
+                                // ...sessionVariables
                             }
                         })
                         .build();

--- a/src/generateDefaultResponse.ts
+++ b/src/generateDefaultResponse.ts
@@ -63,27 +63,32 @@ export function generateDefaultResponse(request: Request, context: Context, data
     // We want to know the channel
     const channel: string = request.channel;
 
-    const GENERATED_NO_ANSWER: ResultVariableInformation = context.session.get('GENERATED_NO_ANSWER');
+    if (!request.attributes) {
+        // just so the following doesn't crash
+        request.attributes = {};
+    }
+
+    const GENERATED_NO_ANSWER: ResultVariableInformation = request.attributes['GENERATED_NO_ANSWER'];
 
     //  Search Results
-    const SEARCH: ResultVariableListItem[] = context.session.get("SEARCH_RESULTS")
+    const SEARCH: ResultVariableListItem[] = Array.isArray(request.attributes["SEARCH_RESULTS"]) ? request.attributes["SEARCH_RESULTS"] : [];
 
     // TOP_FAQ
-    const TOP_FAQ: ResultVariableFAQInformation = context.session.get("TOP_FAQ");
+    const TOP_FAQ: ResultVariableFAQInformation = request.attributes["TOP_FAQ"];
 
-    const FAQS: ResultVariableFAQInformation[] = context.session.get("FAQS");
+    const FAQS: ResultVariableFAQInformation[] = Array.isArray(request.attributes["FAQS"]) ? request.attributes["FAQS"] : [];
 
     // Suggested
-    const SUGGESTED: ResultVariableInformation = context.session.get("SUGGESTED_ANSWER");
+    const SUGGESTED: ResultVariableInformation = request.attributes["SUGGESTED_ANSWER"];
 
     // General Knowledge
-    const GENERAL_KNOWLEDGE: ResultVariableInformation = context.session.get("GENERAL_KNOWLEDGE");
+    const GENERAL_KNOWLEDGE: ResultVariableInformation = request.attributes["GENERAL_KNOWLEDGE"];
 
     // Chat Responses
-    const CHAT_RESPONSE: ResultVariableGeneratedInformation = context.session.get("CHAT_RESPONSE") || context.session.get("CHAT_ANSWER");
+    const CHAT_RESPONSE: ResultVariableGeneratedInformation = request.attributes["CHAT_RESPONSE"] || request.attributes["CHAT_ANSWER"];
 
     // Top Answer / RAG / Chat Answer
-    const AI_ANSWER: ResultVariableGeneratedInformation | ResultVariableInformation = context.session.get("RAG_RESULT") || CHAT_RESPONSE || context.session.get("TOP_ANSWER");
+    const AI_ANSWER: ResultVariableGeneratedInformation | ResultVariableInformation = request.attributes["RAG_RESULT"] || CHAT_RESPONSE || request.attributes["TOP_ANSWER"];
 
     let label: string;
     let displayAnswer: string;
@@ -113,7 +118,7 @@ export function generateDefaultResponse(request: Request, context: Context, data
             label = topLabels?.AI_ANSWER || "AI Answer";
             displayAnswer = `${AI_ANSWER.markdownText}`
             ssmlAnswer = `${AI_ANSWER.text}`;
-            tag = !!context.session.get("RAG_RESULT") ? `KB_RAG` : `KB_TOP_ANSWER`;
+            tag = !!request.attributes["RAG_RESULT"] ? `KB_RAG` : `KB_TOP_ANSWER`;
             if (AI_ANSWER.source) {
                 suggestions.push({
                     title: "Read More",
@@ -236,10 +241,10 @@ export function generateDefaultResponse(request: Request, context: Context, data
                 ssmlAnswer = `${AI_ANSWER.text} ${followUp}`;
             }
 
-            tag = !!context.session.get("RAG_RESULT") ? `KB_RAG` : `KB_TOP_ANSWER`;
+            tag = !!request.attributes["RAG_RESULT"] ? `KB_RAG` : `KB_TOP_ANSWER`;
 
-            const hasRAG = !!context.session.get("RAG_RESULT");
-            const hasChat = !!context.session.get("CHAT_RESPONSE");
+            const hasRAG = !!request.attributes["RAG_RESULT"];
+            const hasChat = !!request.attributes["CHAT_RESPONSE"];
 
             if (hasRAG) {
                 tag = `KB_RAG`;


### PR DESCRIPTION
We shouldn't have kept the variables in the session as they then persist between conversation turns, instead this switches to request attributes.