### PR TITLE
feat: add optional scheduleButton display to chat configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build Commands
+
+```bash
+yarn build      # Compile TypeScript to lib/
+yarn test       # Run all tests
+yarn lint       # Run ESLint
+yarn clean      # Remove lib/ directory
+```
+
+Run a single test file:
+```bash
+yarn mocha --recursive -r ts-node/register "./src/__test__/focusAnswer.test.ts"
+```
+
+## Architecture
+
+This is a question answering handler for the **stentor** conversational AI framework. It processes knowledge base results and generates appropriate responses.
+
+### Core Flow
+
+1. **QuestionAnsweringHandler** (`QuestionAnsweringHandler.ts`) - Extends `AbstractHandler` from stentor. On request:
+   - Retrieves `KnowledgeBaseResult` from session storage (key: `knowledge_base_result`)
+   - Calls `generateResultVariables()` to process results into typed variables
+   - Sets variables on both session and request attributes
+   - Returns default or custom responses based on available data
+
+2. **generateResultVariables** (`generateResultVariables.ts`) - The main processing function that transforms knowledge base results into structured variables:
+   - `TOP_FAQ` - Best FAQ match (uses Fuse.js fuzzy matching)
+   - `TOP_ANSWER` - High-confidence concise answer
+   - `SUGGESTED_ANSWER` - Answer with more context
+   - `RAG_RESULT` - Retrieval-augmented generation result
+   - `GENERAL_KNOWLEDGE` - LLM general knowledge answer
+   - `CHAT_RESPONSE` - Chat strategy response
+   - `SEARCH_RESULTS` - List of document results
+   - `GENERATED_NO_ANSWER` - Generated no-answer response
+
+3. **Response Selection** - Default responses in `constants.ts` use conditional expressions to select the most appropriate response type based on available variables.
+
+### Key Utilities
+
+- **focusAnswer** - Trims answer text to focus on highlighted portions
+- **cleanAnswer** - Sanitizes answer text
+- **generateTextFragmentURL** - Creates URLs with text fragment anchors
+- **question.ts** - Uses `compromise` NLP library to detect questions
+
+### Configuration Options (QuestionAnsweringData)
+
+- `FUZZY_MATCH_FAQS` - Enable/configure FAQ fuzzy matching threshold
+- `MIN_FAQ_MATCH_CONFIDENCE` - Minimum confidence for FAQ matches
+- `QNA_BOT_LONGEST_HIGHLIGHT` - Use longest highlight as top answer (QnABot strategy)
+- `REMOVE_LEADING_LINES_WITHOUT_HIGHLIGHTS` - Focus answer by removing leading context
+- `REMOVE_TRAILING_LINES_WITHOUT_HIGHLIGHTS` - Focus answer by removing trailing context
+
+### Dependencies
+
+- **stentor-*** - Peer dependencies from the stentor framework
+- **fuse.js** - Fuzzy string matching for FAQ matching
+- **compromise** - NLP for question detection
+- **linkifyjs** - URL detection for highlight handling
+
+## Code Standards
+
+- All source files require XAPP AI copyright header: `/*! Copyright (c) <YEAR>, XAPP AI */`
+- Explicit return types required on functions (except test files)
+- Tests located in `src/__test__/` directory

--- a/src/QuestionAnsweringHandler.ts
+++ b/src/QuestionAnsweringHandler.ts
@@ -30,9 +30,18 @@ export interface QuestionAnsweringData extends Data, ResultVariablesConfig {
          */
         followUp?: string;
         /**
-         * Experimental feature to include search results when we have a GENERATED_NO_ANSWER.  
+         * Experimental feature to include search results when we have a GENERATED_NO_ANSWER.
          */
         includeResultsInNoAnswer?: number;
+        /**
+         * Optional schedule button display to add to responses.
+         */
+        scheduleButton?: {
+            /**
+             * The title of the schedule button.  Defaults to "Schedule Service".
+             */
+            title?: string;
+        };
     };
     /**
      * Optional Search Configuration

--- a/src/__test__/generateDefaultResponse.test.ts
+++ b/src/__test__/generateDefaultResponse.test.ts
@@ -612,6 +612,66 @@ describe(`#${generateDefaultResponse.name}()`, () => {
                 }
             });
         });
+        describe("with scheduleButton configured", () => {
+            it("adds ScheduleButton display with default title", () => {
+                const sessionVariables = generateResultVariables(request.rawQuery, REQUEST_WITH_GOOD_HIGHLIGHTED_ANSWER.knowledgeBaseResult, {});
+
+                request = REQUEST_WITH_GOOD_HIGHLIGHTED_ANSWER;
+                request.attributes = { ...sessionVariables };
+
+                context = new ContextBuilder()
+                    .withSessionData({
+                        id: "foo",
+                        data: {
+                            [SESSION_STORAGE_KNOWLEDGE_BASE_RESULT]: REQUEST_WITH_GOOD_HIGHLIGHTED_ANSWER.knowledgeBaseResult,
+                        }
+                    })
+                    .build();
+
+                const response = generateDefaultResponse(request, context, {
+                    chat: {
+                        scheduleButton: {}
+                    }
+                });
+
+                expect(response).to.exist;
+                expect(response.displays).to.have.length(1);
+                expect(response.displays[0]).to.deep.equal({
+                    type: "ScheduleButton",
+                    title: "Schedule Service"
+                });
+            });
+            it("adds ScheduleButton display with custom title", () => {
+                const sessionVariables = generateResultVariables(request.rawQuery, REQUEST_WITH_GOOD_HIGHLIGHTED_ANSWER.knowledgeBaseResult, {});
+
+                request = REQUEST_WITH_GOOD_HIGHLIGHTED_ANSWER;
+                request.attributes = { ...sessionVariables };
+
+                context = new ContextBuilder()
+                    .withSessionData({
+                        id: "foo",
+                        data: {
+                            [SESSION_STORAGE_KNOWLEDGE_BASE_RESULT]: REQUEST_WITH_GOOD_HIGHLIGHTED_ANSWER.knowledgeBaseResult,
+                        }
+                    })
+                    .build();
+
+                const response = generateDefaultResponse(request, context, {
+                    chat: {
+                        scheduleButton: {
+                            title: "Book Appointment"
+                        }
+                    }
+                });
+
+                expect(response).to.exist;
+                expect(response.displays).to.have.length(1);
+                expect(response.displays[0]).to.deep.equal({
+                    type: "ScheduleButton",
+                    title: "Book Appointment"
+                });
+            });
+        });
         describe("with CHAT_RESPONSE variables", () => {
             it("returns as expected", () => {
 

--- a/src/generateDefaultResponse.ts
+++ b/src/generateDefaultResponse.ts
@@ -225,6 +225,8 @@ export function generateDefaultResponse(request: Request, context: Context, data
 
         const suggestionChips = data?.chat?.suggestionChips || [];
 
+        const scheduleButton = data?.chat?.scheduleButton;
+
         const includeResultsInNoAnswer: number = data?.chat?.includeResultsInNoAnswer;
 
         const followUp = typeof data?.chat?.followUp === "string" ? data.chat.followUp : "Any other questions?";
@@ -347,6 +349,14 @@ export function generateDefaultResponse(request: Request, context: Context, data
             }
 
             response.tag = tag;
+
+            // Add schedule button display if configured
+            if (scheduleButton) {
+                response.displays.push({
+                    type: "ScheduleButton",
+                    title: scheduleButton.title || "Schedule Service"
+                });
+            }
         }
     }
 


### PR DESCRIPTION
Add a new `scheduleButton` option to the chat configuration that allows adding a ScheduleButton display to responses. The button title defaults to "Schedule Service" but can be customized.

Also adds CLAUDE.md for codebase documentation.